### PR TITLE
HTTP Interface

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 9fe15688a53c8144b092bb564908bd9a77dd7b04c919894f31c8f9a14fe797c8
-updated: 2016-07-12T13:43:16.22665319-06:00
+hash: 67b0640d05c10d1d239281fbde19d81aa57028436fd847046aff970e3fb128c4
+updated: 2016-08-29T10:23:00.903865774-04:00
 imports:
 - name: github.com/cenk/backoff
   version: 32cd0c5b3aef12c76ed64aaf678f6c79736be7dc
@@ -49,6 +49,10 @@ imports:
   subpackages:
   - proto
   - jsonpb
+- name: github.com/gorilla/context
+  version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
+- name: github.com/gorilla/mux
+  version: 0eeaf8392f5b04950925b8a69fe70f110fa7cbfc
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/olekukonko/tablewriter
@@ -59,6 +63,8 @@ imports:
   version: 300106c228d52c8941d4b3de6054a6062a86dda3
 - name: github.com/shurcooL/sanitized_anchor_name
   version: 10ef21a441db47d8b13ebcc5fd2310f636973c77
+- name: github.com/soheilhy/cmux
+  version: b26951527b125cfd8a8e81142cbe6a6b30abaa99
 - name: github.com/spf13/cobra
   version: 1c44ec8d3f1552cac48999f9306da23c4d8a288b
 - name: github.com/spf13/pflag
@@ -78,7 +84,7 @@ imports:
   - http2/hpack
   - internal/timeseries
 - name: google.golang.org/grpc
-  version: 13edeeffdea7a41d5aad96c28deb4c7bd01a9397
+  version: 0032a855ba5c8a3c8e0d71c2deef354b70af1584
   subpackages:
   - credentials
   - codes
@@ -88,4 +94,12 @@ imports:
   - naming
   - transport
   - peer
-devImports: []
+testImports:
+- name: github.com/davecgh/go-spew
+  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
+  subpackages:
+  - spew
+- name: github.com/pmezard/go-difflib
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  subpackages:
+  - difflib

--- a/glide.yaml
+++ b/glide.yaml
@@ -9,30 +9,32 @@ import:
 - package: github.com/golang/protobuf
   version: 3607a4a99491b23e98d1a68cb408800bdcfb5698
   subpackages:
-  - /proto
+  - proto
 - package: github.com/gogo/protobuf
   version: 2752d97bbd91927dd1c43296dbf8700e50e2708c
   subpackages:
-  - /proto
-  - /protoc-gen-gogo
-  - /gogoproto
+  - proto
+  - protoc-gen-gogo
+  - gogoproto
 - package: github.com/cenk/backoff
   version: 32cd0c5b3aef12c76ed64aaf678f6c79736be7dc
 - package: golang.org/x/net
   subpackages:
-  - /context
+  - context
 - package: google.golang.org/grpc
   version: ~1.x
 - package: github.com/stretchr/testify
   version: c5d7a69bf8a2c9c374798160849c071093e41dd1
   subpackages:
-  - /assert
+  - assert
 - package: github.com/twinj/uuid
 - package: github.com/olekukonko/tablewriter
 - package: github.com/spf13/cobra
 - package: github.com/dustin/go-humanize
 - package: github.com/coreos/pkg
   subpackages:
-  - /capnslog
+  - capnslog
 - package: github.com/gengo/grpc-gateway
   version: faa3576c70e270b37279f045637a7d04f632e353
+- package: github.com/soheilhy/cmux
+  version: ^0.1.1

--- a/server/http.go
+++ b/server/http.go
@@ -1,0 +1,231 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"golang.org/x/net/context"
+
+	"github.com/gorilla/mux"
+	"github.com/jive/postal/api"
+)
+
+func initHTTPServer(s *PostalServer) http.Handler {
+	r := mux.NewRouter()
+	r.HandleFunc("/v1/networks", s.httpHandleNetworks).Methods(http.MethodGet)
+	r.HandleFunc("/v1/networks/{network}", s.httpHandleNetworks).Methods(http.MethodGet)
+
+	r.HandleFunc("/v1/networks/{network}/pools", s.httpHandlePools).Methods(http.MethodGet)
+	r.HandleFunc("/v1/networks/{network}/pools/{pool}", s.httpHandlePools).Methods(http.MethodGet)
+
+	r.HandleFunc("/v1/networks/{network}/bindings", s.httpHandleBindings).Methods(http.MethodGet)
+	r.HandleFunc("/v1/networks/{network}/{addr}", s.httpHandleBindings).Methods(http.MethodGet)
+	r.HandleFunc("/v1/networks/{network}/pools/{pool}/bindings", s.httpHandleBindings).Methods(http.MethodGet)
+
+	r.HandleFunc("/v1/networks/{network}/pools/{pool}/_allocate", s.httpHandleAllocate).Methods(http.MethodPost)
+	r.HandleFunc("/v1/networks/{network}/pools/{pool}/{addr}/_allocate", s.httpHandleAllocate).Methods(http.MethodPost)
+
+	r.HandleFunc("/v1/networks/{network}/pools/{pool}/_bind", s.httpHandleBind).Methods(http.MethodPost)
+	r.HandleFunc("/v1/networks/{network}/pools/{pool}/{addr}/_bind", s.httpHandleBind).Methods(http.MethodPost)
+
+	r.HandleFunc("/v1/networks/{network}/pools/{pool}/bindings/{binding}", s.httpHandleRelease).Methods(http.MethodDelete)
+	r.HandleFunc("/v1/networks/{network}/{addr}", s.httpHandleRelease).Methods(http.MethodDelete)
+
+	s.r = r
+	return r
+}
+
+func (s *PostalServer) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	if origin := req.Header.Get("Origin"); origin != "" {
+		rw.Header().Set("Access-Control-Allow-Origin", origin)
+		rw.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE")
+		rw.Header().Set("Access-Control-Allow-Headers",
+			"Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization")
+	}
+	// Stop here if its Preflighted OPTIONS request
+	if req.Method == "OPTIONS" {
+		return
+	}
+
+	s.r.ServeHTTP(rw, req)
+}
+
+func (s *PostalServer) httpHandleNetworks(w http.ResponseWriter, req *http.Request) {
+	vars := mux.Vars(req)
+	switch req.Method {
+	case http.MethodGet:
+		rangeReq := &api.NetworkRangeRequest{
+			ID:      vars["network"],
+			Filters: map[string]string{},
+		}
+		for _, filter := range req.URL.Query()["f"] {
+			if s := strings.Split(filter, "="); len(s) == 2 {
+				rangeReq.Filters[s[0]] = s[1]
+			}
+		}
+
+		resp, err := s.NetworkRange(context.Background(), rangeReq)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		err = json.NewEncoder(w).Encode(resp)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+	case http.MethodPost:
+	case http.MethodDelete:
+	default:
+
+	}
+
+}
+
+func (s *PostalServer) httpHandlePools(w http.ResponseWriter, req *http.Request) {
+	vars := mux.Vars(req)
+	switch req.Method {
+	case http.MethodGet:
+		rangeReq := &api.PoolRangeRequest{
+			ID: &api.Pool_PoolID{
+				NetworkID: vars["network"],
+				ID:        vars["pool"],
+			},
+			Filters: map[string]string{},
+		}
+		for _, filter := range req.URL.Query()["f"] {
+			if s := strings.Split(filter, "="); len(s) == 2 {
+				rangeReq.Filters[s[0]] = s[1]
+			}
+		}
+
+		resp, err := s.PoolRange(context.Background(), rangeReq)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		err = json.NewEncoder(w).Encode(resp)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+	case http.MethodPost:
+	case http.MethodDelete:
+	default:
+
+	}
+}
+
+func (s *PostalServer) httpHandleBindings(w http.ResponseWriter, req *http.Request) {
+	vars := mux.Vars(req)
+	switch req.Method {
+	case http.MethodGet:
+		rangeReq := &api.BindingRangeRequest{
+			NetworkID: vars["network"],
+			Filters:   map[string]string{},
+		}
+		if addr, ok := vars["addr"]; ok {
+			rangeReq.Filters["_address"] = addr
+		}
+		if pool, ok := vars["pool"]; ok {
+			rangeReq.Filters["_pool"] = pool
+		}
+		for _, filter := range req.URL.Query()["f"] {
+			if s := strings.Split(filter, "="); len(s) == 2 {
+				rangeReq.Filters[s[0]] = s[1]
+			}
+		}
+
+		resp, err := s.BindingRange(context.Background(), rangeReq)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		err = json.NewEncoder(w).Encode(resp)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+	case http.MethodPost:
+	case http.MethodDelete:
+	default:
+
+	}
+}
+
+func (s *PostalServer) httpHandleAllocate(w http.ResponseWriter, req *http.Request) {
+	vars := mux.Vars(req)
+	allocateReq := &api.AllocateAddressRequest{
+		PoolID: &api.Pool_PoolID{
+			NetworkID: vars["network"],
+			ID:        vars["pool"],
+		},
+		Address: vars["addr"],
+	}
+	resp, err := s.AllocateAddress(context.Background(), allocateReq)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	err = json.NewEncoder(w).Encode(resp)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
+func (s *PostalServer) httpHandleBind(w http.ResponseWriter, req *http.Request) {
+	vars := mux.Vars(req)
+	bindReq := &api.BindAddressRequest{
+		PoolID: &api.Pool_PoolID{
+			NetworkID: vars["network"],
+			ID:        vars["pool"],
+		},
+		Address: vars["addr"],
+	}
+	resp, err := s.BindAddress(context.Background(), bindReq)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	err = json.NewEncoder(w).Encode(resp)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
+func (s *PostalServer) httpHandleRelease(w http.ResponseWriter, req *http.Request) {
+	vars := mux.Vars(req)
+	releaseReq := &api.ReleaseAddressRequest{
+		PoolID: &api.Pool_PoolID{
+			NetworkID: vars["network"],
+			ID:        vars["pool"],
+		},
+	}
+
+	if binding, ok := vars["binding"]; ok {
+		releaseReq.BindingID = binding
+	} else {
+		releaseReq.Address = vars["addr"]
+	}
+
+	resp, err := s.ReleaseAddress(context.Background(), releaseReq)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	err = json.NewEncoder(w).Encode(resp)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}

--- a/server/http_test.go
+++ b/server/http_test.go
@@ -1,0 +1,267 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"github.com/jive/postal/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHTTPNetworkRange(t *testing.T) {
+	test := sandboxedServerTest(func(assert *assert.Assertions, client api.PostalClient, httpClient *http.Client, endpoint string) {
+		// Add some networks to the server
+		networkCount := 5
+		networks := map[string]*api.Network{}
+		for i := 0; i < networkCount; i++ {
+			cidr := fmt.Sprintf("10.%d.0.0/16", i)
+			resp, err := client.NetworkAdd(context.TODO(), &api.NetworkAddRequest{
+				Annotations: map[string]string{
+					"foo":      "bar",
+					"netCount": string(i),
+				},
+				Cidr: cidr,
+			})
+			assert.NoError(err)
+			assert.Equal(cidr, resp.Network.Cidr)
+			assert.Equal("bar", resp.Network.Annotations["foo"])
+			assert.Equal(string(i), resp.Network.Annotations["netCount"])
+			networks[resp.Network.ID] = resp.Network
+		}
+		assert.Equal(networkCount, len(networks))
+
+		resp, err := httpClient.Get(endpoint + "/v1/networks")
+		assert.NoError(err)
+		if resp.StatusCode != http.StatusOK {
+			buf := bytes.Buffer{}
+			buf.ReadFrom(resp.Body)
+			fmt.Println("Expected 200 OK, got", resp.Status)
+			fmt.Println(buf.String())
+			t.FailNow()
+		}
+
+		rangeResp := &api.NetworkRangeResponse{}
+		err = json.NewDecoder(resp.Body).Decode(rangeResp)
+		assert.NoError(err)
+
+		assert.Equal(networkCount, len(rangeResp.Networks))
+	})
+
+	test.execute(t)
+}
+
+func TestHTTPNetworkRangeID(t *testing.T) {
+	test := sandboxedServerTest(func(assert *assert.Assertions, client api.PostalClient, httpClient *http.Client, endpoint string) {
+		// Add some networks to the server
+		networkCount := 5
+		networks := map[string]*api.Network{}
+		for i := 0; i < networkCount; i++ {
+			cidr := fmt.Sprintf("10.%d.0.0/16", i)
+			resp, err := client.NetworkAdd(context.TODO(), &api.NetworkAddRequest{
+				Annotations: map[string]string{
+					"foo":      "bar",
+					"netCount": string(i),
+				},
+				Cidr: cidr,
+			})
+			assert.NoError(err)
+			assert.Equal(cidr, resp.Network.Cidr)
+			assert.Equal("bar", resp.Network.Annotations["foo"])
+			assert.Equal(string(i), resp.Network.Annotations["netCount"])
+			networks[resp.Network.ID] = resp.Network
+		}
+		assert.Equal(networkCount, len(networks))
+
+		for id := range networks {
+			httpReq, err := http.NewRequest("GET", (endpoint + "/v1/networks/" + id), nil)
+			assert.NoError(err)
+			resp, err := httpClient.Do(httpReq)
+			assert.NoError(err)
+			if resp.StatusCode != http.StatusOK {
+				buf := bytes.Buffer{}
+				buf.ReadFrom(resp.Body)
+				fmt.Println("Expected 200 OK, got", resp.Status)
+				fmt.Println(buf.String())
+				t.FailNow()
+			}
+
+			rangeResp := &api.NetworkRangeResponse{}
+			err = json.NewDecoder(resp.Body).Decode(rangeResp)
+			assert.NoError(err)
+
+			assert.Equal(1, len(rangeResp.Networks))
+
+			assert.EqualValues(*networks[id], *rangeResp.Networks[0])
+		}
+
+	})
+
+	test.execute(t)
+}
+
+func TestHTTPPoolRange(t *testing.T) {
+	test := sandboxedServerTest(func(assert *assert.Assertions, client api.PostalClient, httpClient *http.Client, endpoint string) {
+		networkResp, networkErr := client.NetworkAdd(context.TODO(), &api.NetworkAddRequest{
+			Annotations: map[string]string{},
+			Cidr:        "10.0.0.0/16",
+		})
+		assert.NoError(networkErr)
+
+		poolCount := 5
+		pools := map[string]*api.Pool{}
+		poolMax := uint64(10)
+		for i := 0; i < poolCount; i++ {
+			resp, err := client.PoolAdd(context.TODO(), &api.PoolAddRequest{
+				NetworkID:   networkResp.Network.ID,
+				Annotations: map[string]string{},
+				Maximum:     poolMax,
+				Type:        api.Pool_DYNAMIC,
+			})
+
+			assert.NoError(err)
+			assert.Equal(networkResp.Network.ID, resp.Pool.ID.NetworkID)
+			assert.Equal(poolMax, resp.Pool.MaximumAddresses)
+			assert.Equal(api.Pool_DYNAMIC, resp.Pool.Type)
+			pools[resp.Pool.ID.ID] = resp.Pool
+		}
+		assert.Equal(poolCount, len(pools))
+
+		httpReq, err := http.NewRequest("GET", (endpoint + "/v1/networks/" + networkResp.Network.ID + "/pools"), nil)
+		assert.NoError(err)
+		resp, err := httpClient.Do(httpReq)
+		assert.NoError(err)
+		if resp.StatusCode != http.StatusOK {
+			buf := bytes.Buffer{}
+			buf.ReadFrom(resp.Body)
+			fmt.Println("Expected 200 OK, got", resp.Status)
+			fmt.Println(buf.String())
+			t.FailNow()
+		}
+
+		rangeResp := &api.PoolRangeResponse{}
+		err = json.NewDecoder(resp.Body).Decode(rangeResp)
+		assert.NoError(err)
+
+		assert.NoError(err)
+		assert.Equal(int32(poolCount), rangeResp.Size_)
+		assert.Equal(poolCount, len(rangeResp.Pools))
+	})
+	test.execute(t)
+}
+
+func TestHTTPNetworkBindingsRange(t *testing.T) {
+	test := sandboxedServerTest(func(assert *assert.Assertions, client api.PostalClient, httpClient *http.Client, endpoint string) {
+		networkResp, networkErr := client.NetworkAdd(context.TODO(), &api.NetworkAddRequest{
+			Annotations: map[string]string{},
+			Cidr:        "10.0.0.0/16",
+		})
+		assert.NoError(networkErr)
+		poolResp, err := client.PoolAdd(context.TODO(), &api.PoolAddRequest{
+			NetworkID:   networkResp.Network.ID,
+			Annotations: map[string]string{},
+			Maximum:     1000,
+			Type:        api.Pool_FIXED,
+		})
+
+		allocResp, allocErr := client.BulkAllocateAddress(context.TODO(), &api.BulkAllocateAddressRequest{
+			PoolID: poolResp.Pool.ID,
+			Cidr:   "10.0.40.0/24",
+		})
+		assert.NoError(allocErr)
+		assert.Equal(0, len(allocResp.GetErrors()))
+		assert.Equal(256, len(allocResp.GetBindings()))
+
+		httpReq, err := http.NewRequest("GET", (endpoint + "/v1/networks/" + networkResp.Network.ID + "/bindings"), nil)
+		assert.NoError(err)
+		resp, err := httpClient.Do(httpReq)
+		assert.NoError(err)
+		if resp.StatusCode != http.StatusOK {
+			buf := bytes.Buffer{}
+			buf.ReadFrom(resp.Body)
+			fmt.Println("Expected 200 OK, got", resp.Status)
+			fmt.Println(buf.String())
+			t.FailNow()
+		}
+
+		rangeResp := &api.BindingRangeResponse{}
+		err = json.NewDecoder(resp.Body).Decode(rangeResp)
+		assert.NoError(err)
+		assert.Equal(int32(256), rangeResp.Size_)
+	})
+	test.execute(t)
+}
+
+func TestHTTPAllocate(t *testing.T) {
+	test := sandboxedServerTest(func(assert *assert.Assertions, client api.PostalClient, httpClient *http.Client, endpoint string) {
+		networkResp, networkErr := client.NetworkAdd(context.TODO(), &api.NetworkAddRequest{
+			Annotations: map[string]string{},
+			Cidr:        "10.0.0.0/16",
+		})
+		assert.NoError(networkErr)
+		poolResp, err := client.PoolAdd(context.TODO(), &api.PoolAddRequest{
+			NetworkID:   networkResp.Network.ID,
+			Annotations: map[string]string{},
+			Maximum:     1000,
+			Type:        api.Pool_FIXED,
+		})
+
+		httpReq, err := http.NewRequest("POST", (endpoint + "/v1/networks/" + networkResp.Network.ID + "/pools/" + poolResp.Pool.ID.ID + "/_allocate"), nil)
+		assert.NoError(err)
+		resp, err := httpClient.Do(httpReq)
+		assert.NoError(err)
+		if resp.StatusCode != http.StatusOK {
+			buf := bytes.Buffer{}
+			buf.ReadFrom(resp.Body)
+			fmt.Println("Expected 200 OK, got", resp.Status)
+			fmt.Println(buf.String())
+			t.FailNow()
+		}
+
+		allocResp := &api.AllocateAddressResponse{}
+		err = json.NewDecoder(resp.Body).Decode(allocResp)
+		assert.NoError(err)
+
+		assert.NotEmpty(allocResp.Binding.Address)
+	})
+	test.execute(t)
+}
+
+func TestHTTPBind(t *testing.T) {
+	test := sandboxedServerTest(func(assert *assert.Assertions, client api.PostalClient, httpClient *http.Client, endpoint string) {
+		networkResp, networkErr := client.NetworkAdd(context.TODO(), &api.NetworkAddRequest{
+			Annotations: map[string]string{},
+			Cidr:        "10.0.0.0/16",
+		})
+		assert.NoError(networkErr)
+		poolResp, err := client.PoolAdd(context.TODO(), &api.PoolAddRequest{
+			NetworkID:   networkResp.Network.ID,
+			Annotations: map[string]string{},
+			Maximum:     1000,
+			Type:        api.Pool_DYNAMIC,
+		})
+
+		httpReq, err := http.NewRequest("POST", (endpoint + "/v1/networks/" + networkResp.Network.ID + "/pools/" + poolResp.Pool.ID.ID + "/_bind"), nil)
+		assert.NoError(err)
+		resp, err := httpClient.Do(httpReq)
+		assert.NoError(err)
+		if resp.StatusCode != http.StatusOK {
+			buf := bytes.Buffer{}
+			buf.ReadFrom(resp.Body)
+			fmt.Println("Expected 200 OK, got", resp.Status)
+			fmt.Println(buf.String())
+			t.FailNow()
+		}
+
+		bindResp := &api.BindAddressResponse{}
+		err = json.NewDecoder(resp.Body).Decode(bindResp)
+		assert.NoError(err)
+
+		assert.NotEmpty(bindResp.Binding.Address)
+	})
+	test.execute(t)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/pkg/capnslog"
+	"github.com/gorilla/mux"
 	"github.com/jive/postal/api"
 	"github.com/jive/postal/postal"
 	"github.com/pkg/errors"
@@ -18,12 +19,15 @@ var (
 
 type PostalServer struct {
 	etcd *clientv3.Client
+	r    *mux.Router
 }
 
 func NewServer(etcd *clientv3.Client) *PostalServer {
-	return &PostalServer{
+	srv := &PostalServer{
 		etcd: etcd,
 	}
+	initHTTPServer(srv)
+	return srv
 }
 
 func (srv *PostalServer) Register(s *grpc.Server) {


### PR DESCRIPTION
Adds support for an http interface to the grpc methods, using the existing Req/Resp types.

Enabled in the server command with the `--http` flag.
